### PR TITLE
Hint at Python version bound to Vim at compile time

### DIFF
--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -13,8 +13,8 @@ import sys
 try:
     import openai
 except ImportError:
-    print("Error: openai module not found. Install with pip.")
-    raise
+    print("Error: OpenAI module not found. Please install with Pip and ensure equality of the versions given by :!python3 -V, and :python3 import sys; print(sys.version)")
+     raise
 import vim
 import os
 

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -13,7 +13,7 @@ import sys
 try:
     import openai
 except ImportError:
-    print("Error: OpenAI module not found. Please install with Pip and ensure equality of the versions given by :!python3 -V, and :python3 import sys; print(sys.version)")
+    print("Error: openai module not found. Please install with Pip and ensure equality of the versions given by :!python3 -V, and :python3 import sys; print(sys.version)")
      raise
 import vim
 import os


### PR DESCRIPTION
Based on [this question](https://www.reddit.com/r/vim/comments/12io0gw/comment/jg4ka97/?utm_source=reddit&utm_medium=web2x&context=3) the error message gives better hints on the python modules according to versions