### PR TITLE
Set response file format & syntax to markdown

### DIFF
--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -40,15 +40,14 @@ function! DisplayChatGPTResponse(response, finish_reason, chat_gpt_session_id)
   let chat_gpt_session_id = a:chat_gpt_session_id
 
   if !bufexists(chat_gpt_session_id)
-    let original_syntax = &syntax
-
     silent execute 'new '. chat_gpt_session_id
     call setbufvar(chat_gpt_session_id, '&buftype', 'nofile')
     call setbufvar(chat_gpt_session_id, '&bufhidden', 'hide')
     call setbufvar(chat_gpt_session_id, '&swapfile', 0)
     setlocal modifiable
     setlocal wrap
-    call setbufvar(chat_gpt_session_id, '&syntax', original_syntax)
+    call setbufvar(chat_gpt_session_id, '&ft', 'markdown')
+    call setbufvar(chat_gpt_session_id, '&syntax', 'markdown')
   endif
 
   if bufwinnr(chat_gpt_session_id) == -1


### PR DESCRIPTION
Hi there, from my use of your plugin I found that since you ask the response to have language annotated codeblocks as in the markdown format I find that it's more beneficial to set the filetype to that format instead of using whatever format we had on the previous file.

This way it's very easy to have any syntax highlighting on the response buffer:

![Peek 2023-06-21 17-34](https://github.com/CoderCookE/vim-chatgpt/assets/9083012/90b4b874-c17d-4dba-9474-a1d609b3fb83)
