### PR TITLE
Create prompt to document code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And more useful env is proxy:
 ```bash
 export OPENAI_PROXY="http://localhost:1087"     # with proxy
 # or
-export OPENAI_API_BASE='https://openai.xxx.cloud/v1'        # refer: https://github.com/egoist/openai-proxy 
+export OPENAI_API_BASE='https://openai.xxx.cloud/v1'        # refer: https://github.com/egoist/openai-proxy
 ```
 
 Alternatively, you can add the following lines to your `.vimrc` file to set up the chatgpt plugin for Vim:
@@ -72,6 +72,8 @@ To use this command type `git commit -v`  then `:GenerateCommit`
 5) `:<>Test '<context>'` Sends the highlighted code to ChatGPT and requests it writes a test, with the option to include additional context.
 5) `:<>Fix '<context>'` Sends the highlighted code to ChatGPT and that it fixes any errors it may find, with the option to include additional context.
 
+6) `:<>Document '<context>'` Sends the highlighted code to ChatGPT and requests documentation, with the option to include additional context.
+
 To use this command, visually select the lines of code you want to extend, then type :Extend 'context', where context is any additional information you want to provide.
 
 The ChatGPT response will be displayed in a new buffer.
@@ -99,6 +101,7 @@ This plugin is not affiliated with or endorsed by OpenAI. You are responsible fo
 - Programming help
 - Code explanations
 - Code review
+- Code documentation
 - Code rewrites
 - Test generation
 - Code fixes

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -171,7 +171,8 @@ function! SendHighlightedCodeToChatGPT(ask, context)
   elseif a:ask == 'review'
     let prompt = 'I have the following code snippet, can you provide a code review for?' . "\n" . yanked_text . "\n"
   elseif a:ask == 'document'
-    let prompt = 'Identify language from this code snippet and returns documentation following language pattern' . "\n" . yanked_text . "\n"
+    let syntax = &syntax
+    let prompt = 'Given the following code snippet written in ' . syntax . ' return documentation following language pattern conventions' . "\n" . yanked_text . "\n"
   elseif a:ask == 'explain'
     let prompt = 'I have the following code snippet, can you explain it?' . "\n" . yanked_text
     if len(a:context) > 0

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -260,7 +260,7 @@ vnoremap <silent> <Plug>(chatgpt-menu) :call ChatGPTMenu()<CR>
 command! -range -nargs=? Ask call SendHighlightedCodeToChatGPT('Ask',<q-args>)
 command! -range -nargs=? Explain call SendHighlightedCodeToChatGPT('explain', <q-args>)
 command! -range Review call SendHighlightedCodeToChatGPT('review', '')
-command! -range Document call SendHighlightedCodeToChatGPT('document', '')
+command! -range -nargs=? Document call SendHighlightedCodeToChatGPT('document', <q-args>)
 command! -range -nargs=? Rewrite call SendHighlightedCodeToChatGPT('rewrite', <q-args>)
 command! -range -nargs=? Test call SendHighlightedCodeToChatGPT('test',<q-args>)
 command! -range -nargs=? Fix call SendHighlightedCodeToChatGPT('fix', <q-args>)

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -171,7 +171,7 @@ function! SendHighlightedCodeToChatGPT(ask, context)
   elseif a:ask == 'review'
     let prompt = 'I have the following code snippet, can you provide a code review for?' . "\n" . yanked_text . "\n"
   elseif a:ask == 'document'
-    let prompt = 'I have the following code snippet, can you provide a documentation for?' . "\n" . yanked_text . "\n"
+    let prompt = 'Identify language from this code snippet and returns documentation following language pattern' . "\n" . yanked_text . "\n"
   elseif a:ask == 'explain'
     let prompt = 'I have the following code snippet, can you explain it?' . "\n" . yanked_text
     if len(a:context) > 0

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -170,6 +170,8 @@ function! SendHighlightedCodeToChatGPT(ask, context)
     endif
   elseif a:ask == 'review'
     let prompt = 'I have the following code snippet, can you provide a code review for?' . "\n" . yanked_text . "\n"
+  elseif a:ask == 'document'
+    let prompt = 'I have the following code snippet, can you provide a documentation for?' . "\n" . yanked_text . "\n"
   elseif a:ask == 'explain'
     let prompt = 'I have the following code snippet, can you explain it?' . "\n" . yanked_text
     if len(a:context) > 0
@@ -218,7 +220,7 @@ endfunction
 " Menu for ChatGPT
 function! s:ChatGPTMenuSink(id, choice)
   call popup_hide(a:id)
-  let choices = {1:'Ask', 2:'rewrite', 3:'explain', 4:'test', 5:'review'}
+  let choices = {1:'Ask', 2:'rewrite', 3:'explain', 4:'test', 5:'review', 6:'document'}
   if a:choice > 0 && a:choice < 6
     call SendHighlightedCodeToChatGPT(choices[a:choice], input('Prompt > '))
   endif
@@ -234,7 +236,7 @@ endfunction
 
 function! ChatGPTMenu() range
   echo a:firstline. a:lastline
-  call popup_menu([ '1. Ask', '2. Rewrite', '3. Explain', '4. Test', '5. Review', ], #{
+  call popup_menu([ '1. Ask', '2. Rewrite', '3. Explain', '4. Test', '5. Review', '6. Document'], #{
         \ pos: 'topleft',
         \ line: 'cursor',
         \ col: 'cursor+2',
@@ -257,6 +259,7 @@ vnoremap <silent> <Plug>(chatgpt-menu) :call ChatGPTMenu()<CR>
 command! -range -nargs=? Ask call SendHighlightedCodeToChatGPT('Ask',<q-args>)
 command! -range -nargs=? Explain call SendHighlightedCodeToChatGPT('explain', <q-args>)
 command! -range Review call SendHighlightedCodeToChatGPT('review', '')
+command! -range Document call SendHighlightedCodeToChatGPT('document', '')
 command! -range -nargs=? Rewrite call SendHighlightedCodeToChatGPT('rewrite', <q-args>)
 command! -range -nargs=? Test call SendHighlightedCodeToChatGPT('test',<q-args>)
 command! -range -nargs=? Fix call SendHighlightedCodeToChatGPT('fix', <q-args>)


### PR DESCRIPTION
Dear @CoderCookE,

I have added a new feature to the vim-chatgpt repository that enhances the functionality of the plugin. This feature introduces the `:Document` command, which allows users to quickly create documentation for your code.

Please review and merge this pull request at your earliest convenience. Feel free to provide any feedback or suggestions for improvement.

Thank you for maintaining this repository and considering my contribution.

Best regards,