### PR TITLE
Extend ChatGPT Prompts with User Custom Prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,29 +58,45 @@ By customizing these options, you can tailor the ChatGPT Vim Plugin to better su
 
 ## Usage
 
-The plugin offers the following commands for interacting with ChatGPT:
+The plugin provides several commands to interact with ChatGPT:
 
-1) `:Ask '<prompt>'` Sends your raw prompt to the ChatGPT API.
+- `Ask`: Ask a question
+- `Rewrite`: Ask the model to rewrite a code snippet more idiomatically
+- `Review`: Request a code review
+- `Document`: Request documentation for a code snippet
+- `Explain`: Ask the model to explain how a code snippet works
+- `Test`: Ask the model to write a test for a code snippet
+- `Fix`: Ask the model to fix an error in a code snippet
 
-To use this command, type :Ask followed by your prompt.
+Each command takes a context as an argument, which can be any text describing the problem or question more specifically.
 
-2) `:<>Review` Sends the highlighted code to ChatGPT and requests a review.
+## Example
 
-To use these commands (:Explain, :Review, or :Rewrite), visually select the lines of code you want to interact with, then type the desired command and press Enter.
+To ask the model to review a code snippet, visually select the code and execute the `Review` command:
 
-4) `:GenerateCommit` Sends entire buffer to ChatGPT and requests a commit messages be generated, then pastes it at the top of the buffer
-To use this command type `git commit -v`  then `:GenerateCommit`
+```vim
+:'<,'>Review 'Can you review this code for me?'
+```
 
-5) `:<>Explain '<context>'` Sends the highlighted code to ChatGPT and requests an explanation, with the option to include additional context.
-5) `:<>Rewrite '<context>'` Sends the highlighted code to ChatGPT and requests a rewritten version, with the option to include additional context.
-5) `:<>Test '<context>'` Sends the highlighted code to ChatGPT and requests it writes a test, with the option to include additional context.
-5) `:<>Fix '<context>'` Sends the highlighted code to ChatGPT and that it fixes any errors it may find, with the option to include additional context.
+The model's response will be displayed in a new buffer.
 
-6) `:<>Document '<context>'` Sends the highlighted code to ChatGPT and requests documentation, with the option to include additional context.
+You can also use `GenerateCommit` command to generate a commit message for the current buffer.
 
-To use this command, visually select the lines of code you want to extend, then type :Extend 'context', where context is any additional information you want to provide.
+## Customization
 
-The ChatGPT response will be displayed in a new buffer.
+You can add custom prompt templates using the `chat_gpt_custom_prompts` variable. This should be a dictionary mapping prompt keys to prompt templates.
+
+For example, to add a 'debug' prompt, you could do:
+
+```vim
+let g:chat_gpt_custom_prompts = {'debug': 'Can you help me debug this code?'}
+```
+
+Afterwards, you can use the `Debug` command like any other command:
+
+```vim
+:'<,'>Debug 'I am encountering an issue where...'
+```
 
 ## Mappings
 

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -50,12 +50,13 @@ if !exists("g:chat_gpt_split_direction")
 endif
 
 let g:prompt_templates = {
-\ 'rewrite': 'Can you rewrite it more idiomatically?',
-\ 'review': 'Can you provide a code review for?',
+\ 'ask': '',
+\ 'rewrite': 'Can you rewrite this more idiomatically?',
+\ 'review': 'Can you provide a code review?',
 \ 'document': 'Return documentation following language pattern conventions.',
-\ 'explain': 'Can you explain it?',
-\ 'test': 'Can you write a test for it?',
-\ 'fix': 'It has an error I need you to fix.'
+\ 'explain': 'Can you explain how this works?',
+\ 'test': 'Can you write a test?',
+\ 'fix':  'I have an error I need you to fix.'
 \}
 
 if exists('g:chat_gpt_custom_prompts')
@@ -234,8 +235,14 @@ function! SendHighlightedCodeToChatGPT(ask, context)
 
   let prompt = a:context . ' ' . "\n" . yanked_text
 
+  echo a:ask
   if has_key(g:prompt_templates, a:ask)
-    let template  = "Given the following code snippet ". g:prompt_templates[a:ask]
+    let template  = g:prompt_templates[a:ask]
+
+    if len(yanked_text) > 0
+      let template = template . " Given the following code snippet: "
+    endif
+
     let prompt = template . "\n" . yanked_text . "\n" . a:context
   endif
 
@@ -325,8 +332,7 @@ endfunction
 
 for i in range(len(g:promptKeys))
   " Commands to interact with ChatGPT
-  execute 'command! -range -nargs=? ' . Capitalize(g:promptKeys[i]) . ' call SendHighlightedCodeToChatGPT(g:promptKeys[i],<q-args>)'
+  execute 'command! -range -nargs=? ' . Capitalize(g:promptKeys[i]) . " call SendHighlightedCodeToChatGPT('" . g:promptKeys[i] . "',<q-args>)"
 endfor
 
-command! -range -nargs=? Ask call SendHighlightedCodeToChatGPT('ask',<q-args>)
 command! GenerateCommit call GenerateCommitMessage()

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -226,6 +226,10 @@ function! SendHighlightedCodeToChatGPT(ask, context)
   \ 'fix': 'It has an error I need you to fix.'
   \}
 
+  if exists('g:chat_gpt_custom_prompts')
+    call extend(prompt_templates, g:chat_gpt_custom_prompts)
+  endif
+
   let prompt = a:context . ' ' . "\n" . yanked_text
 
   if has_key(prompt_templates, a:ask)

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -292,7 +292,7 @@ endfunction
 
 function! s:ChatGPTMenuFilter(id, key)
 
-  if integer(a:key) > 0 && integer(a:key) <= len(g:promptKeys)
+  if a:key > 0 && a:key <= len(g:promptKeys)
     call s:ChatGPTMenuSink(a:id, a:key)
   else " No shortcut, pass to generic filter
     return popup_filter_menu(a:id, a:key)


### PR DESCRIPTION
In the `chatgpt.vim` plugin, added functionality to extend the default prompt templates with user-defined custom prompts. This change allows the users to create their own prompts by defining the `g:chat_gpt_custom_prompts` variable. This enhances the flexibility and applicability of the ChatGPT plugin in different usage scenarios.


To add new prompts or override existing prompts:
```
let g:chat_gpt_custom_prompts = {'hi': 'do you think this is good enough?', 'fix': 'this does not work'}
command! -range -nargs=? Hi call SendHighlightedCodeToChatGPT('hi', <q-args>)
````


ToDo:
Fix the popup menu.