### PR TITLE
Allow user defined personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,30 @@ You can also use `GenerateCommit` command to generate a commit message for the c
 
 ## Customization
 
+### Custom Personas
+
+To introduce custom personas into the system context, simply define them in your `vimrc` file:
+
+```vim
+let g:chat_gpt_custom_persona = {'neptune': 'You are an expert in all things Graph databases'}
+```
+
+With the custom persona defined, you can switch to it using the following command:
+
+```vim
+:GptBe neptune
+```
+
+If you try to switch to a non-existent persona, the plugin will default to the preconfigured `default` persona.
+
+You can also set a persona to be loaded by default when Vim starts, by setting it in your `vimrc`:
+
+```vim
+let g:chat_persona='neptune'
+```
+
+### Commands
+
 You can add custom prompt templates using the `chat_gpt_custom_prompts` variable. This should be a dictionary mapping prompt keys to prompt templates.
 
 For example, to add a 'debug' prompt, you could do:

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -16,7 +16,7 @@ if !exists("g:chat_gpt_temperature")
 endif
 
 if !exists("g:chat_gpt_model")
-  let g:chat_gpt_model = 'gpt-3.5-turbo'
+  let g:chat_gpt_model = 'gpt-4o'
 endif
 
 if !exists("g:chat_gpt_lang")
@@ -26,8 +26,13 @@ endif
 if !exists("g:chat_gpt_split_direction")
   let g:chat_gpt_split_direction = 'horizontal'
 endif
+
 if !exists("g:split_ratio")
   let g:split_ratio = 3
+endif
+
+if !exists("g:chat_persona")
+  let g:chat_persona = 'default'
 endif
 
 let code_wrapper_snippet = "Given the following code snippet: "
@@ -47,6 +52,14 @@ endif
 
 let g:promptKeys = keys(g:prompt_templates)
 
+let g:gpt_personas = {
+\ "default": 'You are a helpful expert programmer we are working together to solve complex coding challenges, and I need your help. Please make sure to wrap all code blocks in ``` annotate the programming language you are using.',
+\}
+
+if exists('g:chat_gpt_custom_persona')
+  call extend(g:gpt_personas, g:chat_gpt_custom_persona)
+endif
+"
 " Function to show ChatGPT responses in a new buffer
 function! DisplayChatGPTResponse(response, finish_reason, chat_gpt_session_id)
   let response = a:response
@@ -144,6 +157,7 @@ def create_client():
         )
     return client
 
+
 def chat_gpt(prompt):
   token_limits = {
     "gpt-3.5-turbo": 4097,
@@ -161,7 +175,10 @@ def chat_gpt(prompt):
   lang = str(vim.eval('g:chat_gpt_lang'))
   resp = lang and f" And respond in {lang}." or ""
 
-  systemCtx = {"role": "system", "content": f"You are a helpful expert programmer we are working together to solve complex coding challenges, and I need your help. Please make sure to wrap all code blocks in ``` annotate the programming language you are using. {resp}"}
+  personas = dict(vim.eval('g:gpt_personas'))
+  persona  = str(vim.eval('g:chat_persona'))
+
+  systemCtx = {"role": "system", "content": f"{personas[persona]} {resp}"}
   messages = []
   session_id = 'gpt-persistent-session' if int(vim.eval('exists("g:chat_gpt_session_mode") ? g:chat_gpt_session_mode : 1')) == 1 else None
 

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -167,6 +167,7 @@ def chat_gpt(prompt):
     "gpt-4-turbo": 128000,
     "gpt-4-turbo-preview": 128000,
     "gpt-4-32k": 32768,
+    "gpt-4o": 128000,
   }
 
   max_tokens = int(vim.eval('g:chat_gpt_max_tokens'))

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -383,3 +383,17 @@ for i in range(len(g:promptKeys))
 endfor
 
 command! GenerateCommit call GenerateCommitMessage()
+
+function! SetPersona(persona)
+    let personas = keys(g:gpt_personas)
+    if index(personas, a:persona) != -1
+      echo 'Persona set to: ' . a:persona
+      let g:chat_persona = a:persona
+    else
+      let g:chat_persona = 'default'
+      echo 'Persona set to default, not found ' . a:persona
+    end
+endfunction
+
+
+command! -nargs=1 GptBe call SetPersona(<q-args>)


### PR DESCRIPTION
Allow users to define and switch personas, during a session.

In `vimrc`
```
let g:chat_gpt_custom_persona = {'neptune': 'You are an expert at all things Graph databases, specifically AWS Neptune.  Your goal is to help me solve complex problems and teach me best practices along the way.  You will consider all alternatives and help me to discover knew possible solutions along the way.  You want me to succeed and see other future opportunities that a Graph database could be used.'}
```

`let g:chat_persona='neptune'`

or

`GptBe neptune`