### PR TITLE
Set linebreak mode in chat buffer and set a stop sequence in a vimrc variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ let g:chat_gpt_temperature = 0.7
 let g:chat_gpt_lang = 'Chinese'
 let g:chat_gpt_split_direction = 'vertical'
 let g:split_ratio=4
+let g:chat_gpt_stop = ' '
 ```
 
  - g:chat_gpt_max_tokens: This option allows you to set the maximum number of tokens (words or characters) that the ChatGPT API will return in its response. By default, it is set to 2000 tokens. You can adjust this value based on your needs and preferences.
@@ -66,6 +67,7 @@ let g:split_ratio=4
  - g:chat_gpt_split_direction: Controls how to open splits, 'vertical' or 'horizontal'. Plugin opens horizontal splits by default.
 By customizing these options, you can tailor the ChatGPT Vim Plugin to better suit your specific needs and preferences.
  - g:split_ratio: Control the split window size. If set 4, the window size will be 1/4.
+ - g:chat_gpt_stop: Stop sequence to send to the ChatGPT API.  Use the stop sequence to only return tokens leading up to the specified stop sequence.  Specifying "World" will cause the API to only return "Hellow" if the output would have been "Hello World!"  The default is to not set a stop sequence.
 
 ## Usage
 

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -78,6 +78,7 @@ function! DisplayChatGPTResponse(response, finish_reason, chat_gpt_session_id)
     call setbufvar(chat_gpt_session_id, '&swapfile', 0)
     setlocal modifiable
     setlocal wrap
+    setlocal linebreak
     call setbufvar(chat_gpt_session_id, '&ft', 'markdown')
     call setbufvar(chat_gpt_session_id, '&syntax', 'markdown')
   endif

--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -20,7 +20,7 @@ if !exists("g:chat_gpt_model")
 endif
 
 if !exists("g:chat_gpt_lang")
-  let g:chat_gpt_lang = ''
+  let g:chat_gpt_lang = v:none
 endif
 
 if !exists("g:chat_gpt_split_direction")
@@ -33,6 +33,10 @@ endif
 
 if !exists("g:chat_persona")
   let g:chat_persona = 'default'
+endif
+
+if !exists("g:chat_gpt_stop")
+  let g:chat_gpt_stop = v:none
 endif
 
 let code_wrapper_snippet = "Given the following code snippet: "
@@ -175,6 +179,7 @@ def chat_gpt(prompt):
   model = str(vim.eval('g:chat_gpt_model'))
   temperature = float(vim.eval('g:chat_gpt_temperature'))
   lang = str(vim.eval('g:chat_gpt_lang'))
+  stop = str(vim.eval('g:chat_gpt_stop'))
   resp = lang and f" And respond in {lang}." or ""
 
   personas = dict(vim.eval('g:gpt_personas'))
@@ -229,7 +234,7 @@ def chat_gpt(prompt):
         messages=messages,
         temperature=temperature,
         max_tokens=max_tokens,
-        stop='',
+        stop=stop,
         stream=True
     )
 


### PR DESCRIPTION
In order to use vim-chatgpt with other LLM APIs, the stop sequence should be set to `v:none` instead of an empty string ''.   

The blank string causes the python openai library to send an empty `stop` parameter to the api, rather than just not sending the `stop` parameter.

It also seems valuable to be able to set the stop sequence in the vimrc file, if someone wanted to specify a parameter.

I think linebreak mode should be enabled by default.  I have trouble reading the chat when whole words are split at the end of the line, instead of starting the word at the beginning of the next line.