### PR TITLE
Switch the parameter set when the model is o* (not gpt-*)

### DIFF
--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -170,6 +170,10 @@ def chat_gpt(prompt):
     "gpt-4-32k": 32768,
     "gpt-4o": 128000,
     "gpt-4o-mini": 128000,
+    "o1": 200000,
+    "o3": 200000,
+    "o3-mini": 200000,
+    "o4-mini": 200000,
   }
 
   max_tokens = int(vim.eval('g:chat_gpt_max_tokens'))
@@ -225,13 +229,21 @@ def chat_gpt(prompt):
 
   try:
     client = create_client()
-    response = client.chat.completions.create(
-        model=model,
-        messages=messages,
+    chat_parameters = {
+          'model':model,
+          'messages':messages,
+          'stream':True
+    }
+    if model.startswith('gpt-'):
+      chat_parameters.update(
         temperature=temperature,
-        max_tokens=max_tokens,
-        stream=True
-    )
+        max_tokens=max_tokens
+      )
+    else:
+      chat_parameters.update(
+        max_completion_tokens=max_tokens
+      )
+    response = client.chat.completions.create(**chat_parameters)
 
     # Iterate through the response chunks
     for chunk in response:


### PR DESCRIPTION
If the model is from the o* series, such as “o4-mini,” the “max_tokens” parameter cannot be used and an error will occur.

```
Error: Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': 'unsupported_parameter'}}
```

To avoid this error, modified the code to switch the parameter set at the time of creation depending on the model.