### PR TITLE
feat: add popup window mode for LLM responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ let g:llm_agent_max_tokens=2000
 let g:llm_agent_session_mode=1
 let g:llm_agent_temperature = 0.7
 let g:llm_agent_lang = 'Chinese'
-let g:llm_agent_split_direction = 'vertical'
+let g:llm_agent_split_direction = 'vertical'  " or 'horizontal' or 'popup'
 let g:split_ratio=4
 let g:llm_agent_enable_tools=1
 let g:chat_persona='default'
@@ -183,7 +183,7 @@ let g:llm_agent_log_level=0  " 0=off, 1=basic, 2=verbose
  - **g:llm_agent_session_mode**: Maintain persistent conversation history across sessions. Default: 1 (enabled). When enabled, conversations are saved to `.vim-llm-agent/history.txt`. Set to 0 to disable history persistence.
  - **g:llm_agent_temperature**: Controls response randomness (0.0-1.0). Higher = more creative, lower = more focused. Default: 0.7
  - **g:llm_agent_lang**: Request responses in a specific language (e.g., `'Chinese'`, `'Spanish'`). Default: none (English)
- - **g:llm_agent_split_direction**: Window split direction: `'vertical'` or `'horizontal'`. Default: `'vertical'`
+ - **g:llm_agent_split_direction**: Window display mode: `'vertical'`, `'horizontal'`, or `'popup'`. Default: `'vertical'`. The `'popup'` option uses Vim 8+ floating window for a non-intrusive overlay display.
  - **g:split_ratio**: Split window size ratio. If set to 4, the window will be 1/4 of the screen. Default: 3
  - **g:chat_persona**: Default AI persona to load on startup. Must match a key in `g:gpt_personas` or `g:llm_agent_custom_persona`. Default: `'default'`. See [Custom Personas](#custom-personas) section.
  - **g:llm_agent_enable_tools**: Enable AI tool/function calling capabilities (allows AI to search files, read files, etc.). Default: 1 (enabled). Supported by OpenAI and Anthropic providers.

--- a/autoload/chatgpt.vim
+++ b/autoload/chatgpt.vim
@@ -55,34 +55,130 @@ EOF
   endif
 endfunction
 
+" Check if popup window support is available
+function! chatgpt#has_popup_support() abort
+  return has('popupwin') && exists('*popup_create')
+endfunction
+
+" Create popup window for LLM output
+function! chatgpt#create_popup_window(chat_gpt_session_id) abort
+  " Calculate popup dimensions
+  let width = min([float2nr(&columns * 0.8), &columns - 4])
+  let height = min([float2nr(&lines * 0.6), &lines - 4])
+  " Ensure position values are at least 2 to avoid border overlap
+  let row = max([2, float2nr((&lines - height) / 2)])
+  let col = max([2, float2nr((&columns - width) / 2)])
+
+  " Get or create buffer
+  let bufnr = bufnr(a:chat_gpt_session_id)
+  if bufnr == -1
+    let bufnr = bufadd(a:chat_gpt_session_id)
+    call bufload(bufnr)
+    call setbufvar(bufnr, '&buftype', 'nofile')
+    call setbufvar(bufnr, '&bufhidden', 'hide')
+    call setbufvar(bufnr, '&swapfile', 0)
+    call setbufvar(bufnr, '&ft', 'markdown')
+    call setbufvar(bufnr, '&syntax', 'markdown')
+    call setbufvar(bufnr, '&wrap', 1)
+    call setbufvar(bufnr, '&linebreak', 1)
+  endif
+
+  " Create popup window
+  let opts = {
+        \ 'line': row,
+        \ 'col': col,
+        \ 'minwidth': width,
+        \ 'maxwidth': width,
+        \ 'minheight': height,
+        \ 'maxheight': height,
+        \ 'border': [1, 1, 1, 1],
+        \ 'borderchars': ['─', '│', '─', '│', '┌', '┐', '┘', '└'],
+        \ 'title': ' LLM Agent ',
+        \ 'padding': [0, 1, 0, 1],
+        \ 'close': 'button',
+        \ 'resize': 1,
+        \ 'wrap': 1,
+        \ 'mapping': 0,
+        \ }
+
+  let winid = popup_create(bufnr, opts)
+
+  " Store popup window ID for later reference
+  let g:llm_agent_popup_winid = winid
+
+  return winid
+endfunction
+
 " Display ChatGPT responses in a buffer
 function! chatgpt#display_response(response, finish_reason, chat_gpt_session_id)
   let response = a:response
   let finish_reason = a:finish_reason
   let chat_gpt_session_id = a:chat_gpt_session_id
-  if !bufexists(chat_gpt_session_id)
-    let split_dir = exists('g:llm_agent_split_direction') ? g:llm_agent_split_direction : (exists('g:chat_gpt_split_direction') ? g:chat_gpt_split_direction : 'vertical')
-    if split_dir ==# 'vertical'
-      silent execute winwidth(0)/g:split_ratio.'vnew '. chat_gpt_session_id
+  let split_dir = exists('g:llm_agent_split_direction') ? g:llm_agent_split_direction : (exists('g:chat_gpt_split_direction') ? g:chat_gpt_split_direction : 'vertical')
+
+  " Handle popup window mode
+  if split_dir ==# 'popup'
+    if !chatgpt#has_popup_support()
+      echohl WarningMsg
+      echo "Popup windows require Vim 8.2+ with +popupwin feature. Falling back to vertical split."
+      echohl None
+      let split_dir = 'vertical'
     else
-      silent execute winheight(0)/g:split_ratio.'new '. chat_gpt_session_id
+      " Check if popup already exists and is valid
+      let popup_exists = exists('g:llm_agent_popup_winid') && g:llm_agent_popup_winid > 0 && popup_getpos(g:llm_agent_popup_winid) != {}
+
+      if !popup_exists
+        call chatgpt#create_popup_window(chat_gpt_session_id)
+      endif
+
+      " Get buffer number from popup or create new one
+      let bufnr = bufnr(chat_gpt_session_id)
+      if bufnr == -1
+        let bufnr = bufadd(chat_gpt_session_id)
+        call bufload(bufnr)
+        call setbufvar(bufnr, '&buftype', 'nofile')
+        call setbufvar(bufnr, '&bufhidden', 'hide')
+        call setbufvar(bufnr, '&swapfile', 0)
+        call setbufvar(bufnr, '&ft', 'markdown')
+        call setbufvar(bufnr, '&syntax', 'markdown')
+        call setbufvar(bufnr, '&wrap', 1)
+        call setbufvar(bufnr, '&linebreak', 1)
+      endif
+
+      " Update popup content
+      let winid = exists('g:llm_agent_popup_winid') ? g:llm_agent_popup_winid : 0
+      if winid > 0
+        call popup_settext(winid, getbufline(bufnr, 1, '$'))
+        " Scroll to bottom of popup
+        call win_execute(winid, 'normal! G')
+      endif
     endif
-    call setbufvar(chat_gpt_session_id, '&buftype', 'nofile')
-    call setbufvar(chat_gpt_session_id, '&bufhidden', 'hide')
-    call setbufvar(chat_gpt_session_id, '&swapfile', 0)
-    setlocal modifiable
-    setlocal wrap
-    setlocal linebreak
-    call setbufvar(chat_gpt_session_id, '&ft', 'markdown')
-    call setbufvar(chat_gpt_session_id, '&syntax', 'markdown')
   endif
 
-  if bufwinnr(chat_gpt_session_id) == -1
-    let split_dir = exists('g:llm_agent_split_direction') ? g:llm_agent_split_direction : (exists('g:chat_gpt_split_direction') ? g:chat_gpt_split_direction : 'vertical')
-    if split_dir ==# 'vertical'
-      execute winwidth(0)/g:split_ratio.'vsplit ' . chat_gpt_session_id
-    else
-      execute winheight(0)/g:split_ratio.'split ' . chat_gpt_session_id
+  " Handle traditional split modes
+  if split_dir !=# 'popup'
+    if !bufexists(chat_gpt_session_id)
+      if split_dir ==# 'vertical'
+        silent execute winwidth(0)/g:split_ratio.'vnew '. chat_gpt_session_id
+      else
+        silent execute winheight(0)/g:split_ratio.'new '. chat_gpt_session_id
+      endif
+      call setbufvar(chat_gpt_session_id, '&buftype', 'nofile')
+      call setbufvar(chat_gpt_session_id, '&bufhidden', 'hide')
+      call setbufvar(chat_gpt_session_id, '&swapfile', 0)
+      setlocal modifiable
+      setlocal wrap
+      setlocal linebreak
+      call setbufvar(chat_gpt_session_id, '&ft', 'markdown')
+      call setbufvar(chat_gpt_session_id, '&syntax', 'markdown')
+    endif
+
+    if bufwinnr(chat_gpt_session_id) == -1
+      if split_dir ==# 'vertical'
+        execute winwidth(0)/g:split_ratio.'vsplit ' . chat_gpt_session_id
+      else
+        execute winheight(0)/g:split_ratio.'split ' . chat_gpt_session_id
+      endif
     endif
   endif
 


### PR DESCRIPTION
Introduce 'popup' as a new option for g:llm_agent_split_direction. This mode uses Vim 8+ floating windows to display AI responses in a non-intrusive overlay. Includes automatic fallback to vertical split when popup support is unavailable. Updates README documentation to reflect the new configuration option and usage details.


<img width="1198" height="653" alt="截屏2026-04-05 17 16 36" src="https://github.com/user-attachments/assets/86e7b30e-1cce-4f7f-accc-9b5afd21b86b" />
